### PR TITLE
fix: release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Security
 
+## [1.0.7] - (2023-08-28)
+
+### Fixed
+
+*   fix: read target output files instead of whole output directory
+
 ## [1.0.6] - (2023-08-20)
 
 ### Added

--- a/domain/generate.go
+++ b/domain/generate.go
@@ -37,16 +37,15 @@ func Generate(ctx context.Context, dest string, mfst manifest.Manifest, opts Gen
 	}
 
 	if !opts.Overwrite && !opts.Clean {
-		var err error
-		existent_files := []file.File{}
-		if existent_files, err = fs.ReadDir(ctx, dest, fs.ReadDirOptions{
+		existent_files, err := fs.ReadFiles(ctx.WithCwd(dest), files, fs.ReadFilesOptions{
 			NoFailOnMissing: true,
-		}); err != nil {
+		})
+		if err != nil {
 			return nil, err
 		}
-		files = lo.Filter[file.File](files, func(item file.File, index int) bool {
+		files = lo.Filter(files, func(item file.File, index int) bool {
 			file_path, _ := item.Abs(ctx)
-			return !lo.ContainsBy[file.File](existent_files, func(other file.File) bool {
+			return !lo.ContainsBy(existent_files, func(other file.File) bool {
 				other_path, _ := other.Abs(ctx)
 				return file_path == other_path
 			})

--- a/fs/file.txt
+++ b/fs/file.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/fs/file1.txt
+++ b/fs/file1.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/fs/file2.txt
+++ b/fs/file2.txt
@@ -1,1 +1,0 @@
-Hello, World!

--- a/fs/mod.go
+++ b/fs/mod.go
@@ -56,6 +56,26 @@ func ReadDir(ctx context.Context, path string, opts ReadDirOptions) ([]file.File
 	return result, nil
 }
 
+type ReadFilesOptions struct {
+	NoFailOnMissing bool
+}
+
+func ReadFiles(ctx context.Context, files []file.File, opts ReadFilesOptions) ([]file.File, error) {
+	read_files := []file.File{}
+	for _, f := range files {
+		path, _ := f.Abs(ctx)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) && opts.NoFailOnMissing {
+				continue
+			}
+			return nil, err
+		}
+		read_files = append(read_files, file.NewFile(path, data))
+	}
+	return read_files, nil
+}
+
 func WriteFiles(ctx context.Context, files []file.File) error {
 	for _, f := range files {
 		path, _ := f.Abs(ctx)

--- a/fs/mod_test.go
+++ b/fs/mod_test.go
@@ -111,6 +111,73 @@ func TestReadDir(t *testing.T) {
 	})
 }
 
+func TestReadFiles(t *testing.T) {
+	t.Run("should return a list of files", func(t *testing.T) {
+		ctx := context.New()
+		dir := t.TempDir()
+		p1 := filepath.Join(dir, "file1.txt")
+		p2 := filepath.Join(dir, "file2.txt")
+		if err := os.WriteFile(p1, []byte("Hello, World!"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p2, []byte("Hello, World!"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		files := []file.File{
+			file.NewFile(p1, []byte("Hello, World!")),
+			file.NewFile(p2, []byte("Hello, World!")),
+		}
+
+		read_files, err := fs.ReadFiles(ctx, files, fs.ReadFilesOptions{})
+
+		assert.NoError(t, err)
+		assert.Len(t, read_files, 2)
+		assert.Equal(t, p1, read_files[0].Path())
+		assert.Equal(t, p2, read_files[1].Path())
+	})
+
+	t.Run("should return a list of files even if some files do not exist and option NoFailOnMissing is true", func(t *testing.T) {
+		ctx := context.New()
+		dir := t.TempDir()
+		p1 := filepath.Join(dir, "file1.txt")
+		p2 := filepath.Join(dir, "file2.txt")
+		if err := os.WriteFile(p1, []byte("Hello, World!"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		files := []file.File{
+			file.NewFile(p1, []byte("Hello, World!")),
+			file.NewFile(p2, []byte("Hello, World!")),
+		}
+		opts := fs.ReadFilesOptions{
+			NoFailOnMissing: true,
+		}
+
+		read_files, err := fs.ReadFiles(ctx, files, opts)
+
+		assert.NoError(t, err)
+		assert.Len(t, read_files, 1)
+		assert.Equal(t, p1, read_files[0].Path())
+	})
+
+	t.Run("should return an error if some files do not exist", func(t *testing.T) {
+		ctx := context.New()
+		dir := t.TempDir()
+		p1 := filepath.Join(dir, "file1.txt")
+		p2 := filepath.Join(dir, "file2.txt")
+		if err := os.WriteFile(p1, []byte("Hello, World!"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		files := []file.File{
+			file.NewFile(p1, []byte("Hello, World!")),
+			file.NewFile(p2, []byte("Hello, World!")),
+		}
+
+		_, err := fs.ReadFiles(ctx, files, fs.ReadFilesOptions{})
+
+		assert.Error(t, err)
+	})
+}
+
 func TestWriteFiles(t *testing.T) {
 	t.Run("should write a list of files", func(t *testing.T) {
 		ctx := context.New()


### PR DESCRIPTION
Now, instead of reading whole output dir, magus reads just the target
output files to check if they exists.